### PR TITLE
fix multiple "C" issue

### DIFF
--- a/build/src/index.js
+++ b/build/src/index.js
@@ -12,7 +12,7 @@ const rules = [
     [/[sz]c/g, '88'], // double digits will be reduced later -- but this is easier to debug ;)
     [/^c(?=[ahkloqrux])/, '4'],
     [/^c/, '8'],
-    [/c(?=[ahkoqux])/, '4'],
+    [/c(?=[ahkoqux])/g, '4'],
     [/c$/, '4'],
     [/x/g, '48'],
     [/p(?!h)/g, '1'],

--- a/build/test/index.test.js
+++ b/build/test/index.test.js
@@ -31,6 +31,7 @@ const FIXTURES = [
     ['Fix', '348'],
     ['Fixx', '34848'],
     ['XXL', '48485'],
+    ['Woodcock', '3844'],
 ];
 console.log(_bright('testing colognePhonetic'));
 let hasErrored = false;

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ const rules: [ RegExp, string ][] = [
   [ /[sz]c/g              , '88' ], // double digits will be reduced later -- but this is easier to debug ;)
   [ /^c(?=[ahkloqrux])/   , '4'  ],
   [ /^c/                  , '8'  ],
-  [ /c(?=[ahkoqux])/      , '4'  ],
+  [ /c(?=[ahkoqux])/g     , '4'  ],
   [ /c$/                  , '4'  ],
   [ /x/g                  , '48' ],
   [ /p(?!h)/g             , '1'  ],

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -37,6 +37,7 @@ const FIXTURES: [phrase: string, expected: string][] = [
   ['Fix', '348'],
   ['Fixx', '34848'],
   ['XXL', '48485'],
+  ['Woodcock', '3844'],
 ];
 
 


### PR DESCRIPTION
One of the RegExps for matching "C" is missing the 'g' flag.   This causes words with more than one C to use the wrong code:

Woodcock should be '3844' but instead is '38484'.

Reference: "R" language function cologne